### PR TITLE
device.py: ensure file descriptors are closed

### DIFF
--- a/user_agent/device.py
+++ b/user_agent/device.py
@@ -3,7 +3,7 @@ import json
 
 
 PACKAGE_DIR = os.path.dirname(os.path.realpath(__file__))
-SMARTPHONE_DEV_IDS = json.load(open(os.path.join(
-    PACKAGE_DIR, 'data/smartphone_dev_id.json')))
-TABLET_DEV_IDS = json.load(open(os.path.join(
-    PACKAGE_DIR, 'data/tablet_dev_id.json')))
+with open(os.path.join(PACKAGE_DIR, 'data/smartphone_dev_id.json')) as f:
+    SMARTPHONE_DEV_IDS = json.load(open(f))
+with open(os.path.join(PACKAGE_DIR, 'data/tablet_dev_id.json')) as f:
+    TABLET_DEV_IDS = json.load(open())

--- a/user_agent/device.py
+++ b/user_agent/device.py
@@ -4,6 +4,6 @@ import json
 
 PACKAGE_DIR = os.path.dirname(os.path.realpath(__file__))
 with open(os.path.join(PACKAGE_DIR, 'data/smartphone_dev_id.json')) as f:
-    SMARTPHONE_DEV_IDS = json.load(open(f))
+    SMARTPHONE_DEV_IDS = json.load(f)
 with open(os.path.join(PACKAGE_DIR, 'data/tablet_dev_id.json')) as f:
-    TABLET_DEV_IDS = json.load(open())
+    TABLET_DEV_IDS = json.load(f)


### PR DESCRIPTION
Out of curiosity I have upgraded python and run tests on one of my projects with `-W error` and one of the warnings that were reported were as follows:

```
  File "/home/immerrr/src/proj/venv/lib/python3.8/site-packages/user_agent/device.py", line 6, in <module>
    SMARTPHONE_DEV_IDS = json.load(open(os.path.join(
ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/immerrr/src/proj/venv/lib/python3.8/site-packages/user_agent/data/smartphone_dev_id.json' mode='r' encoding='UTF-8'>

  File "/home/immerrr/src/proj/venv/lib/python3.8/site-packages/user_agent/device.py", line 8, in <module>
    TABLET_DEV_IDS = json.load(open(os.path.join(
ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/immerrr/src/proj/venv/lib/python3.8/site-packages/user_agent/data/tablet_dev_id.json' mode='r' encoding='UTF-8'>
```

Here's a patch that should fix this.