### PR TITLE
Add Python 3.11 to the testing

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,20 +8,20 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ['3.8', '3.9', '3.10']
+        python: ['3.8', '3.9', '3.10', '3.11']
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
 
     - name: Install dependencies
       run: |
-        pip install -U -r requirements.txt
-        pip install -U -e .
+        pip install --upgrade -r requirements.txt
+        pip install --upgrade -e .
 
     - name: Run tests
       run: |

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -8,20 +8,20 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ['3.8', '3.9', '3.10']
+        python: ['3.8', '3.9', '3.10', '3.11']
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
 
     - name: Install dependencies
       run: |
-        pip install -U -r requirements.txt
-        pip install -U -e .
+        pip install --upgrade -r requirements.txt
+        pip install --upgrade -e .
 
     - name: Run tests
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,20 +8,20 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ['3.8', '3.9', '3.10']
+        python: ['3.8', '3.9', '3.10', '3.11']
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
 
     - name: Install dependencies
       run: |
-        pip install -U -r requirements.txt
-        pip install -U -e .
+        pip install --upgrade -r requirements.txt
+        pip install --upgrade -e .
 
     - name: Run tests
       run: |


### PR DESCRIPTION
https://docs.python.org/3.11/whatsnew/3.11.html
> Python 3.11 is between 10-60% faster than Python 3.10. On average, we measured a 1.25x speedup on the standard benchmark suite.

Test results: https://github.com/cclauss/user_agent/actions